### PR TITLE
Joy2bplus

### DIFF
--- a/Manual/Grizzards.tex
+++ b/Manual/Grizzards.tex
@@ -235,10 +235,10 @@ A      ``Joy2b+''     game      pad     such      as     those      from
 \href{https://retrogameboyz.com/products/atari-8-bit-2-button-action-joystick-control-pad-gamepad-xegs-theme?variant=39665422565431}{RetroGameBoyz.com}
 can also  be used.  Button \encircle{I} will  work as  the \textbf{Fire}
 button.  Button  \encircle{II} will  work  as  the \textbf{Game  Select}
-switch. This gamepad type may not work with the Atari 7800.
+switch. Button \encircle{III} will toggle pausing the game.
 
 An    Atari     7800    controller     will    \emph{not}     work    as
-a two-button controller.
+a two-button controller, even on an Atari 7800 console.
 
 Your gamepad  \emph{must} be  plugged in \emph{before}  you turn  on the
 power,    or    the   extra    button    function    will   not    work.

--- a/Manual/Grizzards.tex
+++ b/Manual/Grizzards.tex
@@ -241,7 +241,7 @@ An    Atari     7800    controller     will    \emph{not}     work    as
 a two-button controller, even on an Atari 7800 console.
 
 Your gamepad  \emph{must} be  plugged in \emph{before}  you turn  on the
-power,    or    the   extra    button    function    will   not    work.
+power,   or    the   extra    button   function(s)   will    not   work.
 \ifdefined\ATARIAGESAVE\else If  using a \ifdefined\DEMO Harmony  or \fi
 Harmony  Encore cartridge,  hold down  the \encircle{B}  or \encircle{I}
 button when you power  on your console, or the gamepad  will not work on

--- a/Manual/Grizzards.tex
+++ b/Manual/Grizzards.tex
@@ -231,9 +231,11 @@ the \textbf{Fire} button. Use the  \encircle{C} button as an alternative
 way  to   press  the   \textbf{Game  Select}   switch  to   access  your
 Grizzard's statistics.
 
-A ``Joy2b+'' game pad such as those from RetroGameBoyz can also be used.
-Button   \encircle{I}   will   work   as   the   \textbf{Fire}   button.
-Button \encircle{II} will work as the \textbf{Game Select} switch.
+A      ``Joy2b+''     game      pad     such      as     those      from
+\href{https://retrogameboyz.com/products/atari-8-bit-2-button-action-joystick-control-pad-gamepad-xegs-theme?variant=39665422565431}{RetroGameBoyz.com}
+can also  be used.  Button \encircle{I} will  work as  the \textbf{Fire}
+button.  Button  \encircle{II} will  work  as  the \textbf{Game  Select}
+switch. This gamepad type may not work with the Atari 7800.
 
 An    Atari     7800    controller     will    \emph{not}     work    as
 a two-button controller.

--- a/Source/Banks/Bank00/Bank00.s
+++ b/Source/Banks/Bank00/Bank00.s
@@ -40,8 +40,8 @@
           .include "ShowPicture.s"
 
 DoLocal:
-          cpy #ServiceColdStart
-          beq ColdStart
+          cpy #ServiceWarmStart
+          beq Attract
 
           cpy #ServiceSaveToSlot
           beq SaveToSlot

--- a/Source/Common/EndBank.s
+++ b/Source/Common/EndBank.s
@@ -48,8 +48,7 @@ Wired:
 
 ;;; Cold-start the system.
 GoColdStart:
-          ldy # ServiceColdStart
-          BankJump ColdStart, ColdStartBank
+          .BankJump ColdStart, ColdStartBank
 
 ;;; Go to the current map memory bank, and jump to DoMap.
 GoMap:
@@ -83,6 +82,10 @@ GoCombat:
           sta BankSwitch0 + CombatBank0To127
           jmp DoLocal
 
+GoWarmStart:
+          ldy # ServiceWarmStart
+          ldx # ColdStartBank
+          ;; fall through
 ;;; Perform a far call to a memory bank with a specific local
 ;;; service routine to perform; eg, this is how we handle sounds,
 ;;; text displays, and the common map header and footer code;

--- a/Source/Common/EndBank.s
+++ b/Source/Common/EndBank.s
@@ -5,9 +5,9 @@
 EndBank:
 
           .if DEMO
-            BankEndAddress = $ff78      ; keep this as high as possible
+            BankEndAddress = $ff76      ; keep this as high as possible
           .else
-            BankEndAddress = $ff50      ; keep this as high as possible
+            BankEndAddress = $ff4e      ; keep this as high as possible
           .fi
           .if (* > BankEndAddress) || (* < $f000)
             .error "Bank ", BANK, " overran ROM space (ending at ", *, "; must end by ", BankEndAddress, ")"

--- a/Source/Common/Enums.s
+++ b/Source/Common/Enums.s
@@ -194,7 +194,7 @@
 
           ServiceAttract = $1e
           ServiceChooseGrizzard = $31
-          ServiceColdStart = $00
+          ServiceWarmStart = $00
           ServiceConfirmNewGame = $32
           ServiceLoadGrizzard = $22
           ServiceLoadProvinceData = $21

--- a/Source/Common/Enums.s
+++ b/Source/Common/Enums.s
@@ -337,3 +337,8 @@
           ButtonC = ButtonII
 
           ButtonIII = $20
+;;; 
+          SystemFlag7800 = $10
+          SystemFlagP1Gamepad = $20
+          SystemFlagP0Gamepad = $40
+          SystemFlagPaused = $80

--- a/Source/Common/Enums.s
+++ b/Source/Common/Enums.s
@@ -339,6 +339,6 @@
           ButtonIII = $20
 ;;; 
           SystemFlag7800 = $10
-          SystemFlagP1Gamepad = $20
+          SystemFlagP1Gamepad = $20   ; not actually used in Grizzards
           SystemFlagP0Gamepad = $40
-          SystemFlagPaused = $80
+          SystemFlagPaused = $80      ; must be the high bit

--- a/Source/Common/Enums.s
+++ b/Source/Common/Enums.s
@@ -327,6 +327,13 @@
 ;;; 
 ;;; Game tunable
           GrizzardMetamorphosisXP = 27
+;;; 
+;;; Gamepad buttons
+          ButtonI = $80
+          ButtonB = ButtonI
+          ButtonFire = ButtonI
 
+          ButtonII = $40
+          ButtonC = ButtonII
 
-;;; Audited 2022-02-16 BRPocock
+          ButtonIII = $20

--- a/Source/Common/VBlank.s
+++ b/Source/Common/VBlank.s
@@ -29,8 +29,9 @@ VBlank: .block
           sta NewSWCHB
 +
 
-          bit SystemFlags
-          bvc NotGenesis
+          lda SystemFlags
+          and #SystemFlagP0Gamepad
+          beq NotGenesis
 
           tya                 ; Y = 0
           .if 11 != BANK        ; ran out of space in Bank 11 ($b)
@@ -68,9 +69,9 @@ ButtonsChanged:
           bne DoneButtonIISelect
 
           lda NewSWCHB
-          ora #~SWCHBSelect     ; zero = Select button pressed
+          and #~SWCHBSelect     ; zero = Select button pressed
+          ora #$40              ; ensure a 1 bit
           sta NewSWCHB
-          sta DebounceSWCHB
 DoneButtonIISelect:
           .if 11 != BANK
             lda NewButtons

--- a/Source/Common/VBlank.s
+++ b/Source/Common/VBlank.s
@@ -69,8 +69,7 @@ ButtonsChanged:
           bne DoneButtonIISelect
 
           lda NewSWCHB
-          and #~SWCHBSelect     ; zero = Select button pressed
-          ora #$40              ; ensure a 1 bit
+          lda #~SWCHBSelect | $40     ; zero = Select button pressed, $40 = changed
           sta NewSWCHB
 DoneButtonIISelect:
           .if 11 != BANK

--- a/Source/Common/VBlank.s
+++ b/Source/Common/VBlank.s
@@ -29,9 +29,8 @@ VBlank: .block
           sta NewSWCHB
 +
 
-          lda SWCHB
-          and #SWCHBP0Genesis
-          beq NotGenesis
+          bit SystemFlags
+          bvc NotGenesis
 
           tya                 ; Y = 0
           .if 11 != BANK        ; ran out of space in Bank 11 ($b)
@@ -53,40 +52,34 @@ NotGenesis:
           ora #ButtonI
 DoneButtonI:
           sta NewButtons
-          sta Score + 1         ; XXX
-
-          ldx DebounceButtons   ; XXX
-          stx Score + 2         ; XXX
 
           cmp DebounceButtons   ; buttons down bits are ones here too
           bne ButtonsChanged
 
 ButtonsSame:
           sty NewButtons        ; Y = 0
-          sty Score             ; XXX
           jmp DoneButtons
 
 ButtonsChanged:
           sta DebounceButtons
           eor #ButtonI | ButtonII | ButtonIII | 1
           sta NewButtons      ; buttons down are 0 bits, $01 to flag change
-          sta Score             ; XXX
           and #ButtonII       ; C / II button pressed?
-          ;; bne DoneButtonIISelect
+          bne DoneButtonIISelect
 
-          ;; lda NewSWCHB
-          ;; ora #~SWCHBSelect     ; zero = Select button pressed
-          ;; sta NewSWCHB
-          ;; sta DebounceSWCHB
+          lda NewSWCHB
+          ora #~SWCHBSelect     ; zero = Select button pressed
+          sta NewSWCHB
+          sta DebounceSWCHB
 DoneButtonIISelect:
           .if 11 != BANK
             lda NewButtons
             and #ButtonIII
             bne DoneButtons
 
-            lda Pause
-            eor #$80
-            sta Pause
+            lda SystemFlags
+            eor #SystemFlagPaused
+            sta SystemFlags
           .fi
 DoneButtons:
 

--- a/Source/Common/VCS-Consts.s
+++ b/Source/Common/VCS-Consts.s
@@ -54,12 +54,9 @@
           ;; Console
           SWCHBReset = $01
           SWCHBSelect = $02
-          SWCHB7800 = $04 ; this is something we set ourselves
           .if TV != SECAM
             SWCHBColor = $08
           .fi
-          SWCHBP0Genesis = $10
-          SWCHBP1Genesis = $20
           SWCHBP0Advanced = $40
           SWCHBP1Advanced = $80
 

--- a/Source/Common/VSync.s
+++ b/Source/Common/VSync.s
@@ -8,7 +8,7 @@
 ;;; (The cost in wired memory is a factor.)
           
 VSync: .block
-          lda #ENABLED | VBlankLatchINPT45
+          lda #ENABLED
           sta VBLANK
 
           sta VSYNC

--- a/Source/Common/ZeroPage.s
+++ b/Source/Common/ZeroPage.s
@@ -31,7 +31,7 @@ Pointer:
 GameMode:
           .byte ?
 
-Pause:
+SystemFlags:
           .byte ?
 ;;; 
 ;;; Game play/progress indicators -- global

--- a/Source/Common/ZeroPage.s
+++ b/Source/Common/ZeroPage.s
@@ -13,6 +13,9 @@
 
           * = $80
 ZeroPage:
+;;; This must be the first address.
+SystemFlags:
+          .byte ?
 ;;; 
 ;;; General-purpose short-term variable
 ;;;
@@ -31,8 +34,6 @@ Pointer:
 GameMode:
           .byte ?
 
-SystemFlags:
-          .byte ?
 ;;; 
 ;;; Game play/progress indicators -- global
 

--- a/Source/Routines/AtariAgeSave-EEPROM-Driver.s
+++ b/Source/Routines/AtariAgeSave-EEPROM-Driver.s
@@ -161,4 +161,4 @@ i2cWaitForAck:
           bcs -
           jmp i2cStopWrite      ; tail call
 
-          .fill 46              ; In case this has to grow
+          .fill 36              ; In case this has to grow

--- a/Source/Routines/Attract.s
+++ b/Source/Routines/Attract.s
@@ -8,10 +8,12 @@ Attract:  .block
 
           .WaitScreenTop
 
-          ldx #$80
+          ;; DO NOT clear location $80 itself
+          ;; It is SystemFlags.
+          ldx #$7f
           lda #0
 ZeroRAM:
-          sta $80 - 1, x
+          sta $80, x
           dex
           bne ZeroRAM
 

--- a/Source/Routines/Attract.s
+++ b/Source/Routines/Attract.s
@@ -129,7 +129,7 @@ DoneSelect:
           lda NewButtons
           beq DoneButtons
 
-          and #PRESSED
+          and #ButtonI
           beq Leave
 
 DoneButtons:

--- a/Source/Routines/AttractStory.s
+++ b/Source/Routines/AttractStory.s
@@ -271,7 +271,7 @@ CheckFire:
           lda NewButtons
           beq LoopMe
 
-          and #PRESSED
+          and #ButtonI
           bne LoopMe
 
 SelectSlot:

--- a/Source/Routines/BeginNamePrompt.s
+++ b/Source/Routines/BeginNamePrompt.s
@@ -153,7 +153,7 @@ NoStick:
           lda NewButtons
           beq Done
 
-          and # PRESSED
+          and # ButtonI
           bne Done
 
 ButtonPressed:

--- a/Source/Routines/BeginNamePrompt.s
+++ b/Source/Routines/BeginNamePrompt.s
@@ -153,7 +153,7 @@ NoStick:
           lda NewButtons
           beq Done
 
-          and # ButtonI
+          and #ButtonI
           bne Done
 
 ButtonPressed:

--- a/Source/Routines/BeginNamePrompt.s
+++ b/Source/Routines/BeginNamePrompt.s
@@ -131,7 +131,7 @@ CursorPosGross:
           bne DoneSwitches
 
           .WaitScreenBottom
-          jmp GoColdStart
+          jmp GoWarmStart
 
 DoneSwitches:
           lda NewSWCHA

--- a/Source/Routines/BeginOrResume.s
+++ b/Source/Routines/BeginOrResume.s
@@ -57,7 +57,7 @@ SkipStick:
           lda NewButtons
           beq SkipButton
 
-          .BitBit PRESSED
+          .BitBit ButtonI
           beq SlotOK
 
 SkipButton:

--- a/Source/Routines/BeginOrResume.s
+++ b/Source/Routines/BeginOrResume.s
@@ -57,7 +57,7 @@ SkipStick:
           lda NewButtons
           beq SkipButton
 
-          .BitBit ButtonI
+          and #ButtonI
           beq SlotOK
 
 SkipButton:

--- a/Source/Routines/ColdStart.s
+++ b/Source/Routines/ColdStart.s
@@ -5,8 +5,7 @@
 ;;;
 ;;; This routine is called once at startup, and must be in Bank 0.
 ;;;
-;;; After a Game Over, this may be called again to return to the title
-;;; screen with a full reset.
+;;; It must never be called again, or you'll lose '7800 detection.
 
 ColdStart:         .block
           sei
@@ -34,6 +33,8 @@ ZeroTIALoop:
 
           sty SWACNT            ; Y = 0
           sty SWBCNT
+
+          sty SystemFlags
 	
 ResetStack:
           .mvx s, #$ff

--- a/Source/Routines/ColdStart.s
+++ b/Source/Routines/ColdStart.s
@@ -33,14 +33,7 @@ ZeroTIALoop:
           sta VBLANK
 
           sty SWACNT            ; Y = 0
-          ;; only set inputs on the bits that we can actually read
-          ;; AKA the “Combat flags trick”
-          .if TV == SECAM
-            lda # $ff - (SWCHBReset | SWCHBSelect | SWCHBP0Advanced | SWCHBP1Advanced)
-          .else
-            lda # $ff - (SWCHBReset | SWCHBSelect | SWCHBColor | SWCHBP0Advanced | SWCHBP1Advanced)
-          .fi
-          sta SWBCNT
+          sty SWBCNT
 	
 ResetStack:
           .mvx s, #$ff

--- a/Source/Routines/CombatMainScreen.s
+++ b/Source/Routines/CombatMainScreen.s
@@ -356,7 +356,7 @@ UserControls:
           lda NewButtons
           beq ScreenDone
 
-          and #PRESSED
+          and #ButtonI
           bne ScreenDone
 
 GoDoMove:

--- a/Source/Routines/CombatVBlank.s
+++ b/Source/Routines/CombatVBlank.s
@@ -242,34 +242,6 @@ NoReset:
 
 NoSelect:
 
-;;; XXX the pause code should be in some other place rather than being duplicated here
-;;; Moreover, Pause does not even affect combat mode, so this is maybe wasted code?
-          .if TV == SECAM
-
-            lda DebounceSWCHB
-            and #SWCHBP1Advanced ; SECAM pause
-            sta Pause
-
-          .else
-
-            lda DebounceSWCHB
-            .BitBit SWCHBColor
-            bne NoPause
-
-            and #SWCHB7800
-            beq +
-            lda Pause
-            eor #$ff
-+
-            sta Pause
-            rts
-
-NoPause:
-            ldy # 0             ; XXX necessary?
-            sty Pause
-
-          .fi
-
 DoneSwitches:
           rts
 

--- a/Source/Routines/ConfirmErase.s
+++ b/Source/Routines/ConfirmErase.s
@@ -89,7 +89,7 @@ DoneSelect:
           bne DoneSwitches
 
           .WaitScreenBottom
-          jmp GoColdStart
+          jmp GoWarmStart
 
 DoneSwitches:
           lda NewSWCHA

--- a/Source/Routines/ConfirmErase.s
+++ b/Source/Routines/ConfirmErase.s
@@ -112,7 +112,7 @@ DoneStick:
           lda NewButtons
           beq DoneButtons
 
-          and #PRESSED
+          and #ButtonI
           bne DoneButtons
 
           .mva NextSound, #SoundBlip

--- a/Source/Routines/ConfirmNewGame.s
+++ b/Source/Routines/ConfirmNewGame.s
@@ -83,7 +83,7 @@ DoneSelect:
           bne DoneSwitches
 
           .WaitScreenBottom
-          jmp GoColdStart
+          jmp GoWarmStart
 
 DoneSwitches:       
           lda NewSWCHA

--- a/Source/Routines/ConfirmNewGame.s
+++ b/Source/Routines/ConfirmNewGame.s
@@ -107,7 +107,7 @@ DoneStick:
           lda NewButtons
           beq DoneButtons
 
-          and #PRESSED
+          and #ButtonI
           bne DoneButtons
 
           .mva NextSound, #SoundBlip

--- a/Source/Routines/Death.s
+++ b/Source/Routines/Death.s
@@ -42,7 +42,7 @@ LoopFirst:
 +
 	lda NewButtons
           beq +
-          and #PRESSED
+          and #ButtonI
           beq Leave
 +
           lda AlarmCountdown

--- a/Source/Routines/DetectConsole.s
+++ b/Source/Routines/DetectConsole.s
@@ -59,7 +59,7 @@ is2600:
           lda SystemFlags
           and #~SystemFlag7800
 End:
-          sta SWCHB
+          sta SystemFlags
           ;; fall through to DetectGenesis
           .bend
 

--- a/Source/Routines/DetectConsole.s
+++ b/Source/Routines/DetectConsole.s
@@ -58,10 +58,8 @@ is7800:
 is2600:
           lda SystemFlags
           and #~SystemFlag7800
-
 End:
           sta SWCHB
           ;; fall through to DetectGenesis
           .bend
 
-;;; Audited 2022-02-15 BRPocock

--- a/Source/Routines/DetectConsole.s
+++ b/Source/Routines/DetectConsole.s
@@ -46,18 +46,19 @@ confirmFlashed:
           bne is2600         ; if not $00 then loaded via Harmony Menu on 2600
 
           ldy $80             ; else get the value saved by the CDFJ driver
-          bne is7800
+          beq is2600
 
 ;;; end of console detection routine, y contains results
 
-is2600:
-          lda SWCHB
-          and #~SWCHB7800
-          jmp End
-
 is7800:
-          lda SWCHB
-          ora #SWCHB7800
+          lda SystemFlags
+          ora #SystemFlag7800
+          gne End
+
+is2600:
+          lda SystemFlags
+          and #~SystemFlag7800
+
 End:
           sta SWCHB
           ;; fall through to DetectGenesis

--- a/Source/Routines/DetectGenesis.s
+++ b/Source/Routines/DetectGenesis.s
@@ -17,13 +17,13 @@ DetectGenesis:      .block
           lda INPT1
           bpl NotGenesis
 
-          lda SWCHB
-          ora #SWCHBP0Genesis
+          lda SystemFlags
+          ora #SystemFlagP0Gamepad
           gne DoneGenesis
 
 NotGenesis:
-          lda SWCHB
-          and #~SWCHBP0Genesis
+          lda SystemFlags
+          and #~SystemFlagP0Gamepad
 DoneGenesis:
           sta SWCHB
 

--- a/Source/Routines/DetectGenesis.s
+++ b/Source/Routines/DetectGenesis.s
@@ -25,7 +25,7 @@ NotGenesis:
           lda SystemFlags
           and #~SystemFlagP0Gamepad
 DoneGenesis:
-          sta SWCHB
+          sta SystemFlags
 
           .WaitScreenBottom
 

--- a/Source/Routines/Failure.s
+++ b/Source/Routines/Failure.s
@@ -107,7 +107,7 @@ DoneSwitches:
           jmp Loop
 
 Reset:
-          jmp GoColdStart
+          jmp GoWarmStart
 
 ;;; 
 MemoryText:

--- a/Source/Routines/GrizzardChooser.s
+++ b/Source/Routines/GrizzardChooser.s
@@ -48,7 +48,7 @@ Loop:
           bne DoneSwitches
 
           .WaitScreenBottom
-          jmp GoColdStart
+          jmp GoWarmStart
 
 DoneSwitches:       
           lda NewSWCHA

--- a/Source/Routines/GrizzardChooser.s
+++ b/Source/Routines/GrizzardChooser.s
@@ -81,7 +81,7 @@ DoneStick:
           lda NewButtons
           beq DoneButtons
 
-          and #PRESSED
+          and #ButtonI
           bne DoneButtons
 
           .mva NextSound, #SoundBlip

--- a/Source/Routines/GrizzardDepot.s
+++ b/Source/Routines/GrizzardDepot.s
@@ -266,7 +266,7 @@ SwitchesDone:
           lda NewButtons
           beq TriggerDone
 
-          .BitBit PRESSED
+          .BitBit ButtonI
           bne TriggerDone
 
           .mva GameMode, #ModeMap

--- a/Source/Routines/GrizzardDepot.s
+++ b/Source/Routines/GrizzardDepot.s
@@ -266,7 +266,7 @@ SwitchesDone:
           lda NewButtons
           beq TriggerDone
 
-          .BitBit ButtonI
+          and #ButtonI
           bne TriggerDone
 
           .mva GameMode, #ModeMap

--- a/Source/Routines/GrizzardStatsScreen.s
+++ b/Source/Routines/GrizzardStatsScreen.s
@@ -17,7 +17,7 @@ FirstLoop:
           lda NewButtons
           beq NoButton
 
-          and #PRESSED
+          and #ButtonI
           beq Select
 
 NoButton:

--- a/Source/Routines/Inquire.s
+++ b/Source/Routines/Inquire.s
@@ -91,7 +91,7 @@ StickDone:
           lda NewButtons
           beq NoButton
 
-          .BitBit PRESSED
+          .BitBit ButtonI
           bne NoButton
 
           lda #SoundHappy

--- a/Source/Routines/Inquire.s
+++ b/Source/Routines/Inquire.s
@@ -91,7 +91,7 @@ StickDone:
           lda NewButtons
           beq NoButton
 
-          .BitBit ButtonI
+          and #ButtonI
           bne NoButton
 
           lda #SoundHappy

--- a/Source/Routines/LearntMove.s
+++ b/Source/Routines/LearntMove.s
@@ -78,7 +78,7 @@ SwitchesDone:
 
 Leave:
           cmp #ModeColdStart
-          beq GoColdStart
+          beq GoWarmStart
 
           rts
 

--- a/Source/Routines/LevelUp.s
+++ b/Source/Routines/LevelUp.s
@@ -129,7 +129,7 @@ SwitchesDone:
 
 Leave:
           cmp #ModeColdStart
-          beq GoColdStart
+          beq GoWarmStart
 
           rts
 ;;; 

--- a/Source/Routines/MapTopService.s
+++ b/Source/Routines/MapTopService.s
@@ -21,8 +21,8 @@ TopOfScreenService: .block
           .ldacolu COLGRAY, 0
           sta COLUBK
 ;;; 
-          lda Pause
-          beq DrawScore
+          bit SystemFlags
+          bpl DrawScore
           .enc "minifont"
           .mva StringBuffer + 0, #"P"
           .mva StringBuffer + 1, #"A"
@@ -161,8 +161,8 @@ NoPuff:
 +
           sta pp1l
 MaybeAnimate:
-          lda Pause
-          bne AnimationFrameReady
+          bit SystemFlags
+          bmi AnimationFrameReady
           lda SpriteAction, x
           cmp #SpriteCombat
           beq Flippy

--- a/Source/Routines/Potion.s
+++ b/Source/Routines/Potion.s
@@ -90,7 +90,7 @@ DoneStick:
           lda NewButtons
           beq DoneButton
 
-          and #PRESSED
+          and #ButtonI
           bne DoneButton
 
           ldx DeltaX

--- a/Source/Routines/RevealBear.s
+++ b/Source/Routines/RevealBear.s
@@ -80,7 +80,7 @@ BearDelay2:
           lda NewButtons
           beq BearLoop
 
-          .BitBit PRESSED
+          .BitBit ButtonI
           bne BearLoop
 
           .mva NextSound, # SoundDrone

--- a/Source/Routines/RevealBear.s
+++ b/Source/Routines/RevealBear.s
@@ -80,7 +80,7 @@ BearDelay2:
           lda NewButtons
           beq BearLoop
 
-          .BitBit ButtonI
+          and #ButtonI
           bne BearLoop
 
           .mva NextSound, # SoundDrone

--- a/Source/Routines/SelectSlot.s
+++ b/Source/Routines/SelectSlot.s
@@ -198,7 +198,7 @@ StickDone:
 
           ;; — hold Fire button
           lda INPT4
-          and #PRESSED
+          and #ButtonI
           bne ThisIsNotAStickUp
 
           .SetUtterance Phrase_EraseSlot
@@ -209,7 +209,7 @@ StickDone:
 EliminationMode:
           ;; Release button to exit Elimination Mode
           lda INPT4
-          and #PRESSED
+          and #ButtonI
           bne ThisIsNotAStickUp
 
           ;; Push stick Up to erase the selected slot
@@ -261,7 +261,7 @@ StillGotTime:
           lda NewButtons
           beq DoneButtons
 
-          .BitBit PRESSED
+          .BitBit ButtonI
           beq SlotOK
 
 DoneButtons:

--- a/Source/Routines/SelectSlot.s
+++ b/Source/Routines/SelectSlot.s
@@ -207,9 +207,8 @@ StickDone:
 ;;; 
 EliminationMode:
           ;; Release button to exit Elimination Mode
-          lda INPT4
-          and #ButtonI
-          bne ThisIsNotAStickUp
+          bit INPT4
+          bmi ThisIsNotAStickUp
 
           ;; Push stick Up to erase the selected slot
           lda SWCHA

--- a/Source/Routines/SelectSlot.s
+++ b/Source/Routines/SelectSlot.s
@@ -197,9 +197,8 @@ StickDone:
           bne ThisIsNotAStickUp
 
           ;; — hold Fire button
-          lda INPT4
-          and #ButtonI
-          bne ThisIsNotAStickUp
+          bit INPT4
+          bmi ThisIsNotAStickUp
 
           .SetUtterance Phrase_EraseSlot
 
@@ -261,7 +260,7 @@ StillGotTime:
           lda NewButtons
           beq DoneButtons
 
-          .BitBit ButtonI
+          and #ButtonI
           beq SlotOK
 
 DoneButtons:

--- a/Source/Routines/Signpost.s
+++ b/Source/Routines/Signpost.s
@@ -199,7 +199,7 @@ DoneDrawing:
           bne NoButton
           lda NewButtons
           beq NoButton
-          .BitBit PRESSED
+          .BitBit ButtonI
           bne NoButton
 
 GetNextMode:

--- a/Source/Routines/Signpost.s
+++ b/Source/Routines/Signpost.s
@@ -197,9 +197,11 @@ DoneDrawing:
 
           lda AlarmCountdown      ; require 1-2s to tick before accepting button press; see #140
           bne NoButton
+
           lda NewButtons
           beq NoButton
-          .BitBit ButtonI
+
+          and #ButtonI
           bne NoButton
 
 GetNextMode:

--- a/Source/Routines/SpriteMovement.s
+++ b/Source/Routines/SpriteMovement.s
@@ -2,8 +2,8 @@
 ;;; Copyright © 2021-2022 Bruce-Robert Pocock
 
 SpriteMovement:     .block
-          lda Pause
-          beq +
+          lda SystemFlags
+          bpl +
           rts
 +
           ldx SpriteCount

--- a/Source/Routines/UserInput.s
+++ b/Source/Routines/UserInput.s
@@ -5,8 +5,7 @@ UserInput:          .block
 
 CheckButton:
           lda NewButtons
-          jmp CheckSwitches
-          ;; beq CheckSwitches
+          beq CheckSwitches
 
           and #ButtonI
           bne CheckSwitches
@@ -62,9 +61,12 @@ SetPause:
             bne Pause7800
 
             lda NewSWCHB
+            beq DonePause
+
             eor DebounceSWCHB
             and #SWCHBColor
             beq DonePause
+
 TogglePause:
             lda SystemFlags
             eor #SystemFlagPaused

--- a/Source/Routines/UserInput.s
+++ b/Source/Routines/UserInput.s
@@ -7,7 +7,7 @@ CheckButton:
           lda NewButtons
           beq CheckSwitches
 
-          and #PRESSED
+          and #ButtonI
           bne CheckSwitches
 
           .if !DEMO

--- a/Source/Routines/UserInput.s
+++ b/Source/Routines/UserInput.s
@@ -41,8 +41,9 @@ NoReset:
 NoSelect:
           .if TV == SECAM
 
-          ;;  XXX make this toggle?
-            lda DebounceSWCHB
+            lda NewSWCHB
+            bne DonePause
+
             and #SWCHBP1Advanced        ; SECAM pause
             beq +
             lda SystemFlags
@@ -53,6 +54,7 @@ NoSelect:
             and #~SystemFlagPaused
 SetPause:
             sta SystemFlags
+DonePause:
 
           .else
 

--- a/Source/Routines/UserInput.s
+++ b/Source/Routines/UserInput.s
@@ -63,13 +63,23 @@ SetPause:
             lda NewSWCHB
             beq DonePause
 
-            eor DebounceSWCHB
             and #SWCHBColor
-            beq DonePause
+            bne UnPause
+
+            lda SystemFlags
+            ora #SystemFlagPaused
+            gne SaveFlags
+
+UnPause:
+            lda SystemFlags
+            and #~SystemFlagPaused
+            sta SystemFlags
+            jmp DonePause
 
 TogglePause:
             lda SystemFlags
             eor #SystemFlagPaused
+SaveFlags:
             sta SystemFlags
             jmp DonePause
 

--- a/Source/Routines/WinnerFireworks.s
+++ b/Source/Routines/WinnerFireworks.s
@@ -122,7 +122,7 @@ WipeProvinceFlags:
 
           .FarJSR SaveKeyBank, ServiceSaveToSlot
 
-          jmp GoColdStart
+          jmp GoWarmStart
 ;;; 
 AgainText:
           .MiniText "AGAIN!"


### PR DESCRIPTION
Fix Joy2b+ support, in particular for Atari 7800 consoles.
Eliminate using SWCHB as extra flags storage.
Eliminate re-running the Cold Start routine (so that flags are not overwritten).
Merge Pause with Genesis/Joy2b+ gamepad detection and '7800 console detection into SystemFlags byte.
Do not overwrite SystemFlags when clearing (the rest of) RAM.
Map Button III to toggle Pause.
Update manual.